### PR TITLE
Elixir Update

### DIFF
--- a/lib/contentful/delivery.ex
+++ b/lib/contentful/delivery.ex
@@ -119,9 +119,9 @@ defmodule Contentful.Delivery do
 
   defp client_headers(access_token) do
     [
-      {"authorization", "Bearer #{access_token}"},
-      {"Accept", "application/json"},
-      {"User-Agent", "Contentful-Elixir"}
+      {:"authorization", "Bearer #{access_token}"},
+      {:"Accept", "application/json"},
+      {:"User-Agent", "Contentful-Elixir"}
     ]
   end
 

--- a/lib/contentful/request.ex
+++ b/lib/contentful/request.ex
@@ -13,7 +13,7 @@ defmodule Contentful.Request do
 
   @spec request(method, String.t, map) :: error | success
   def request(:get, url, params) do
-    headers = params[:headers]
+    headers = Keyword.new params[:headers]
 
     response = HTTPotion.get(url, headers: headers, timeout: 4_000)
     try do


### PR DESCRIPTION
The second argument of the request HTTPotion.get must be a Keyword List.
Elixir 1.5 made it mandatory to have keys as symbols instead of strings.